### PR TITLE
Potential fix for code scanning alert no. 2: `TrustManager` that accepts all certificates

### DIFF
--- a/e-common/src/main/java/com/ecode/utils/OkHttpUtils.java
+++ b/e-common/src/main/java/com/ecode/utils/OkHttpUtils.java
@@ -6,14 +6,8 @@ import com.ecode.exception.BaseException;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.*;
 
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
 import java.io.IOException;
 import java.net.URLEncoder;
-import java.security.SecureRandom;
-import java.security.cert.X509Certificate;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.Semaphore;
@@ -35,13 +29,10 @@ public class OkHttpUtils {
         if (okHttpClient == null) {
             synchronized (OkHttpUtils.class) {
                 if (okHttpClient == null) {
-                    TrustManager[] trustManagers = buildTrustManagers();
                     okHttpClient = new OkHttpClient.Builder()
                             .connectTimeout(15, TimeUnit.SECONDS)
                             .writeTimeout(20, TimeUnit.SECONDS)
                             .readTimeout(20, TimeUnit.SECONDS)
-                            .sslSocketFactory(createSSLSocketFactory(trustManagers), (X509TrustManager) trustManagers[0])
-                            .hostnameVerifier((hostName, session) -> true)
                             .retryOnConnectionFailure(true)
                             .build();
                     addHeader("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Safari/537.36");
@@ -249,42 +240,6 @@ public class OkHttpUtils {
         }
     }
 
-
-    /**
-     * 生成安全套接字工厂，用于https请求的证书跳过
-     *
-     * @return
-     */
-    private static SSLSocketFactory createSSLSocketFactory(TrustManager[] trustAllCerts) {
-        SSLSocketFactory ssfFactory = null;
-        try {
-            SSLContext sc = SSLContext.getInstance("SSL");
-            sc.init(null, trustAllCerts, new SecureRandom());
-            ssfFactory = sc.getSocketFactory();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        return ssfFactory;
-    }
-
-    private static TrustManager[] buildTrustManagers() {
-        return new TrustManager[]{
-                new X509TrustManager() {
-                    @Override
-                    public void checkClientTrusted(X509Certificate[] chain, String authType) {
-                    }
-
-                    @Override
-                    public void checkServerTrusted(X509Certificate[] chain, String authType) {
-                    }
-
-                    @Override
-                    public X509Certificate[] getAcceptedIssuers() {
-                        return new X509Certificate[]{};
-                    }
-                }
-        };
-    }
 
     /**
      * 自定义一个接口回调


### PR DESCRIPTION
Potential fix for [https://github.com/xuanyue1024/e-code/security/code-scanning/2](https://github.com/xuanyue1024/e-code/security/code-scanning/2)

In general, the fix is to stop using a custom `TrustManager` that trusts all certificates, and instead rely on the default system trust store (or a specific keystore containing the certificates that should be trusted). For OkHttp, the safest default behavior is to not call `.sslSocketFactory(...)` or `.hostnameVerifier(...)` at all; OkHttp will then use the platform’s default SSL configuration and hostname verification. If a custom trust store is required (e.g., to trust a specific self-signed certificate), that certificate should be placed into a `KeyStore` and a proper `TrustManagerFactory` should be used to obtain a validating `X509TrustManager`.

The single best way to fix the current code without changing functionality beyond security hardening is:

1. Remove the insecure custom `TrustManager` (i.e., delete `buildTrustManagers()` and `createSSLSocketFactory(...)`).
2. Remove the call to `.sslSocketFactory(...)` that uses this unsafe trust manager.
3. Remove the `.hostnameVerifier((hostName, session) -> true)` override so that hostname verification works normally again.
4. Keep the existing timeouts, retry configuration, and headers intact.

This keeps the overall behavior of `OkHttpUtils` the same (same timeouts, same singleton client, same headers) while restoring proper TLS certificate and hostname validation. All required classes for the remaining code (`OkHttpClient`, `Request`, etc.) are already imported; once we remove the SSL customization, the imports related solely to the insecure configuration (`SSLContext`, `SSLSocketFactory`, `TrustManager`, `X509TrustManager`, `SecureRandom`, `X509Certificate`) become unused and can be removed. No new methods or external libraries are needed for this fix.

Concretely, in `e-common/src/main/java/com/ecode/utils/OkHttpUtils.java`:

- In the constructor, delete lines 38–44 that create and use `trustManagers` and the permissive hostname verifier, and just build a default `OkHttpClient` with timeouts and retry settings.
- Delete the entire `createSSLSocketFactory` method.
- Delete the entire `buildTrustManagers` method.
- Remove now-unused SSL-related imports at the top of the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
